### PR TITLE
Bugfixes: lingering resources

### DIFF
--- a/mflow/mflow.py
+++ b/mflow/mflow.py
@@ -115,7 +115,7 @@ class Stream(object):
         self.address = address
         self.zmq_copy = copy
         self.zmq_track = not copy
-        
+
         # If socket is used for receiving messages, create receive handler
         if mode == zmq.SUB or mode == zmq.PULL:
             self.receiver = ReceiveHandler(self.socket, copy=copy)
@@ -205,7 +205,7 @@ class Stream(object):
             raise
         except:
             logger.exception('Unable to decode message - skipping')
-            
+
         # Clear remaining sub-messages if exist
         self.receiver.flush(receive_is_successful)
 

--- a/mflow/mflow.py
+++ b/mflow/mflow.py
@@ -80,8 +80,10 @@ class Stream(object):
 
         if not context:
             self.context = zmq.Context()
+            self._context_is_owned = True
         else:
             self.context = context
+            self._context_is_owned = False
         self.socket = self.context.socket(mode)
         if mode == zmq.SUB:
             self.socket.setsockopt_string(zmq.SUBSCRIBE, '')
@@ -158,6 +160,8 @@ class Stream(object):
                 self.socket.disconnect(self.address)
             finally:
                 self.socket.close()
+                if self._context_is_owned:
+                    self.context.term()
 
             logger.info("Disconnected")
         except:

--- a/mflow/mflow.py
+++ b/mflow/mflow.py
@@ -153,8 +153,12 @@ class Stream(object):
             # Stop the socket event listener.
             self._socket_event_listener.stop()
 
-            self.socket.disconnect(self.address)
-            self.socket.close()
+            # Even if disconnect fails, we need to close.
+            try:
+                self.socket.disconnect(self.address)
+            finally:
+                self.socket.close()
+
             logger.info("Disconnected")
         except:
             logger.debug(sys.exc_info()[1])


### PR DESCRIPTION
fixed two bugs regarding lingering resources:

- close socket even if disconnect fails
- terminate ZMQ context, if we created it

these caused warnings, specifically in the bsread test suite